### PR TITLE
Fix Memory visibility race condition generating new set of tuneables

### DIFF
--- a/src/bayes_optuna/optuna_hpo.py
+++ b/src/bayes_optuna/optuna_hpo.py
@@ -208,27 +208,26 @@ class Objective(TrialDetails):
         finally:
             self.experiment.resultsAvailableCond.release()
 
-        # Define search space
-        for tunable in self.tunables:
-            if tunable["value_type"].lower() == "double":
-                tunable_value = trial.suggest_discrete_uniform(
-                    tunable["name"], tunable["lower_bound"], tunable["upper_bound"], tunable["step"]
-                )
-            elif tunable["value_type"].lower() == "integer":
-                tunable_value = trial.suggest_int(
-                    tunable["name"], tunable["lower_bound"], tunable["upper_bound"], tunable["step"]
-                )
-            elif tunable["value_type"].lower() == "categorical":
-                tunable_value = trial.suggest_categorical(tunable["name"], tunable["choices"])
-
-            experiment_tunables.append({"tunable_name": tunable["name"], "tunable_value": tunable_value})
-
-        config["experiment_tunables"] = experiment_tunables
-
-        logger.debug("Experiment tunables: " + str(experiment_tunables))
-
         try:
             self.experiment.resultsAvailableCond.acquire()
+            # Define search space
+            for tunable in self.tunables:
+                if tunable["value_type"].lower() == "double":
+                    tunable_value = trial.suggest_discrete_uniform(
+                        tunable["name"], tunable["lower_bound"], tunable["upper_bound"], tunable["step"]
+                    )
+                elif tunable["value_type"].lower() == "integer":
+                    tunable_value = trial.suggest_int(
+                        tunable["name"], tunable["lower_bound"], tunable["upper_bound"], tunable["step"]
+                    )
+                elif tunable["value_type"].lower() == "categorical":
+                    tunable_value = trial.suggest_categorical(tunable["name"], tunable["choices"])
+
+                experiment_tunables.append({"tunable_name": tunable["name"], "tunable_value": tunable_value})
+
+            config["experiment_tunables"] = experiment_tunables
+
+            logger.debug("Experiment tunables: " + str(experiment_tunables))
             self.experiment.trialDetails.trial_json_object = experiment_tunables
         finally:
             self.experiment.resultsAvailableCond.release()


### PR DESCRIPTION
There is currently a inter-thread memory visibility issue and/or race condition where tunable values are calculated in one thread, and are not visible to thread handling REST/gRPC requests.  This occasionally results in empty tunables being returned to clients.

This change moves generating the tuneable values to within the code section where `self.experiment.resultsAvailableCond` is held, therefore creating a synchronization and memory barrier to ensure generated values are visible to threads accessing the shared `experiment_tunables` state