### PR TITLE
add function_variables key in JSON validation

### DIFF
--- a/src/json_validate.py
+++ b/src/json_validate.py
@@ -69,6 +69,11 @@ trial_generate_schema = {
                 "value_type": {"type": "string"},
                 "hpo_algo_impl": {"type": "string"},
                 "objective_function": {"type": "string"},
+                "function_variables": {
+                    "type": "array",
+                    "value_type": {"type": "string"},
+                    "name": {"type": "string"}
+                },
                 "tunables": {
                     "type": "array",
                     "value_type": {"type": "string"},


### PR DESCRIPTION
Signed-off-by: Saad Khan <saakhan@redhat.com>

This PR adds the function_variables key back in the search space JSON which was failing the validation process.
The function_variables key was removed earlier as part of the feature enhancement under issue https://github.com/kruize/hpo/pull/30 where we have planned to separate this and the objective function in a different API.
