### PR TITLE
Generate importance of all tunables and plots after the experiment

### DIFF
--- a/Dockerfile.hpo
+++ b/Dockerfile.hpo
@@ -37,6 +37,7 @@ RUN microdnf install -y python39 gcc-c++ python39-devel python39-pip\
     && microdnf -y install shadow-utils \
     # Setup the user for non-arbitrary UIDs with OpenShift
     && useradd -d ${HPO_HOME} -u ${UID} -g 0 -m -s /bin/bash ${USER} \
+    && mkdir -p ${HPO_HOME}/app/src \
     && chmod -R g+rwx ${HPO_HOME} \
     && microdnf -y remove shadow-utils \
     && microdnf clean all
@@ -44,7 +45,7 @@ RUN microdnf install -y python39 gcc-c++ python39-devel python39-pip\
 # Switch to the non root user
 USER ${UID}
 
-# copy the requirements file to the app direcotry to install required modules
+# copy the requirements file to the app directory to install required modules
 COPY requirements.txt index.html ${HPO_HOME}/app/
 
 # Copy ML hyperparameter tuning code

--- a/design/API.md
+++ b/design/API.md
@@ -165,7 +165,7 @@ Generate various plots after an experiment is complete.
 ```
 'GET /plot?experiment_name={name}&type={plot_type}'
 
-curl -o tunables_importance.html 'http://<URL>:<PORT>/plot?experiment_name=name&type=tunables_importance'
+curl -o tunable_importance.html 'http://<URL>:<PORT>/plot?experiment_name=name&type=tunable_importance'
 
 Response:
 Status code   Response body
@@ -175,8 +175,9 @@ Status code   Response body
 
 Supported plot type:
 type                        Description
-tunables_importance         Plot importance of all tunables
+tunable_importance          Plot importance of all tunables
 optimization_history        Plot optimization history of all trials
 parallel_coordinate         Plot the high-dimensional tunable relationships
 slice                       Plot the tunable relationship as slice
 ```
+Note: In cases of a single trial experiment and no variance in objective function value, tunable_importance plot doesn't generate.

--- a/design/API.md
+++ b/design/API.md
@@ -159,3 +159,24 @@ Status code   Response body
 200            OK
 503            Service Unavailable
 ```
+
+## Plots
+Generate various plots after an experiment is complete.
+```
+'GET /plot?experiment_name={name}&type={plot_type}'
+
+curl -o tunables_importance.html 'http://<URL>:<PORT>/plot?experiment_name=name&type=tunables_importance'
+
+Response:
+Status code   Response body
+200            html file containing the plot for the given type
+400            Corresponding error message for Bad request
+404            Experiment/Resource not found   
+
+Supported plot type:
+type                        Description
+tunables_importance         Plot importance of all tunables
+optimization_history        Plot optimization history of all trials
+parallel_coordinate         Plot the high-dimensional tunable relationships
+slice                       Plot the tunable relationship as slice
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ jsonschema
 grpcio
 click
 protobuf==3.19.4
+plotly

--- a/rest_requirements.txt
+++ b/rest_requirements.txt
@@ -2,3 +2,4 @@ optuna
 requests
 scikit-optimize
 jsonschema
+plotly

--- a/scripts/cluster-helpers.sh
+++ b/scripts/cluster-helpers.sh
@@ -107,6 +107,9 @@ function native_terminate() {
 	ps -u | grep service.py | grep -v grep | awk '{print $2}' | xargs kill -9 >/dev/null 2>&1
 	check_err "Failed to stop HPO Service!"
 
+	# delete plots after HPO terminates
+	rm -r plots
+
 	echo
 	echo "### Successfully Terminated"
 	echo

--- a/src/bayes_optuna/optuna_hpo.py
+++ b/src/bayes_optuna/optuna_hpo.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import optuna
 import threading
+import json
 
 from logger import get_logger
 
@@ -163,7 +164,7 @@ class HpoExperiment:
 
             # Get the hyperparameter importance
             importance = optuna.importance.get_param_importances(study)
-            logger.info("Importance of all tunables: " + str(importance))
+            logger.info("Importance of all tunables: " + str(json.dumps(importance)))
 
             try:
                 self.resultsAvailableCond.acquire()

--- a/src/bayes_optuna/optuna_hpo.py
+++ b/src/bayes_optuna/optuna_hpo.py
@@ -161,6 +161,10 @@ class HpoExperiment:
 
             logger.debug("All trials: " + str(trials))
 
+            # Get the hyperparameter importance
+            importance = optuna.importance.get_param_importances(study)
+            logger.info("Importance of all tunables: " + str(importance))
+
             try:
                 self.resultsAvailableCond.acquire()
                 optimal_value = {"objective_function": {

--- a/src/bayes_optuna/optuna_hpo.py
+++ b/src/bayes_optuna/optuna_hpo.py
@@ -163,8 +163,15 @@ class HpoExperiment:
             logger.debug("ALL TRIALS: " + str(trials))
 
             # Get the hyperparameter importance
-            importance = optuna.importance.get_param_importances(study)
-            logger.info("TUNABLES IMPORTANCE: " + str(json.dumps(importance)))
+            try:
+                importance = optuna.importance.get_param_importances(study)
+                logger.info("TUNABLES IMPORTANCE: " + str(json.dumps(importance)))
+            except ValueError:
+                logger.warn("Cannot evaluate tunable importance with only a single trial")
+            except RuntimeError:
+                logger.warn("Encountered zero total variance to calculate tunable importance")
+            except:
+                logger.warn("Encountered issues calculating tunable importance")
 
             # Generate different plots
             plots = ["tunable_importance", "optimization_history", "slice", "parallel_coordinate"]
@@ -173,25 +180,24 @@ class HpoExperiment:
                     dirName = "plots/" + self.experiment_name
                     os.makedirs(dirName, exist_ok=True)
                     plotsDir = os.path.dirname(os.path.realpath(dirName))
-                except:
-                    logger.warn("Issues in creating the directory for plots")
-                if plot_type == "tunable_importance":
-                  plot = optuna.visualization.plot_param_importances(study)
-                  plotFile = plotsDir + "/" + self.experiment_name + "/tunable_importance.html"
-                if plot_type == "optimization_history":
-                    plot = optuna.visualization.plot_optimization_history(study)
-                    plotFile = plotsDir + "/" + self.experiment_name + "/optimization_history.html"
-                if plot_type == "slice":
-                    plot = optuna.visualization.plot_slice(study)
-                    plotFile = plotsDir + "/" + self.experiment_name + "/slice.html"
-                if plot_type == "parallel_coordinate":
-                    plot = optuna.visualization.plot_parallel_coordinate(study)
-                    plotFile = plotsDir + "/" + self.experiment_name + "/parallel_coordinate.html"
-                # Commenting out contour plots as it gets hung sometimes when there are lot of tunables for a 100 trial experiment
-                #if plot_type == "contour":
-                    #plot = optuna.visualization.plot_contour(study)
-                    #plotFile = plotsDir + "/" + self.experiment_name + "/contour.html"
-                try:
+
+                    if plot_type == "tunable_importance":
+                        plot = optuna.visualization.plot_param_importances(study)
+                        plotFile = plotsDir + "/" + self.experiment_name + "/tunable_importance.html"
+                    if plot_type == "optimization_history":
+                        plot = optuna.visualization.plot_optimization_history(study)
+                        plotFile = plotsDir + "/" + self.experiment_name + "/optimization_history.html"
+                    if plot_type == "slice":
+                        plot = optuna.visualization.plot_slice(study)
+                        plotFile = plotsDir + "/" + self.experiment_name + "/slice.html"
+                    if plot_type == "parallel_coordinate":
+                        plot = optuna.visualization.plot_parallel_coordinate(study)
+                        plotFile = plotsDir + "/" + self.experiment_name + "/parallel_coordinate.html"
+                    # Commenting out contour plots as it gets hung sometimes when there are lot of tunables for a 100 trial experiment
+                    #if plot_type == "contour":
+                        #plot = optuna.visualization.plot_contour(study)
+                        #plotFile = plotsDir + "/" + self.experiment_name + "/contour.html"
+
                     func = open(plotFile, "w")
                     func.write(plot.to_html())
                     func.close()

--- a/src/bayes_optuna/optuna_hpo.py
+++ b/src/bayes_optuna/optuna_hpo.py
@@ -162,48 +162,11 @@ class HpoExperiment:
 
             logger.debug("ALL TRIALS: " + str(trials))
 
-            # Get the hyperparameter importance
-            try:
-                importance = optuna.importance.get_param_importances(study)
-                logger.info("TUNABLES IMPORTANCE: " + str(json.dumps(importance)))
-            except ValueError:
-                logger.warn("Cannot evaluate tunable importance with only a single trial")
-            except RuntimeError:
-                logger.warn("Encountered zero total variance to calculate tunable importance")
-            except:
-                logger.warn("Encountered issues calculating tunable importance")
+            # Generate tunable importance
+            self.generate_importance(study)
 
-            # Generate different plots
-            plots = ["tunable_importance", "optimization_history", "slice", "parallel_coordinate"]
-            for plot_type in plots:
-                try:
-                    dirName = "plots/" + self.experiment_name
-                    os.makedirs(dirName, exist_ok=True)
-                    plotsDir = os.path.dirname(os.path.realpath(dirName))
-
-                    if plot_type == "tunable_importance":
-                        plot = optuna.visualization.plot_param_importances(study)
-                        plotFile = plotsDir + "/" + self.experiment_name + "/tunable_importance.html"
-                    if plot_type == "optimization_history":
-                        plot = optuna.visualization.plot_optimization_history(study)
-                        plotFile = plotsDir + "/" + self.experiment_name + "/optimization_history.html"
-                    if plot_type == "slice":
-                        plot = optuna.visualization.plot_slice(study)
-                        plotFile = plotsDir + "/" + self.experiment_name + "/slice.html"
-                    if plot_type == "parallel_coordinate":
-                        plot = optuna.visualization.plot_parallel_coordinate(study)
-                        plotFile = plotsDir + "/" + self.experiment_name + "/parallel_coordinate.html"
-                    # Commenting out contour plots as it gets hung sometimes when there are lot of tunables for a 100 trial experiment
-                    #if plot_type == "contour":
-                        #plot = optuna.visualization.plot_contour(study)
-                        #plotFile = plotsDir + "/" + self.experiment_name + "/contour.html"
-
-                    func = open(plotFile, "w")
-                    func.write(plot.to_html())
-                    func.close()
-                    logger.info("ACCESS " + plot_type + " CHART AT <REST_SERVICE_URL>/plot?" + "experiment_name=" + self.experiment_name + "&type=" + plot_type)
-                except:
-                    logger.warn("Issues creating" + plot_type + " html file")
+            # Generate plots
+            self.generate_plots(study)
 
             try:
                 self.resultsAvailableCond.acquire()
@@ -243,6 +206,51 @@ class HpoExperiment:
             self.resultsAvailableCond.notify()
         finally:
             self.resultsAvailableCond.release()
+
+    def generate_importance(self, study):
+        try:
+            importance = optuna.importance.get_param_importances(study)
+            logger.info("TUNABLES IMPORTANCE: " + str(json.dumps(importance)))
+        except ValueError:
+            logger.warn("Cannot evaluate tunable importance with only a single trial")
+        except RuntimeError:
+            logger.warn("Encountered zero total variance to calculate tunable importance")
+        except:
+            logger.warn("Encountered issues calculating tunable importance")
+
+    def generate_plots(self, study):
+        # Generate different plots
+        plots = ["tunable_importance", "optimization_history", "slice", "parallel_coordinate"]
+        for plot_type in plots:
+            try:
+                dirName = "plots/" + self.experiment_name
+                os.makedirs(dirName, exist_ok=True)
+                plotsDir = os.path.dirname(os.path.realpath(dirName))
+
+                if plot_type == "tunable_importance":
+                    plot = optuna.visualization.plot_param_importances(study)
+                    plotFile = plotsDir + "/" + self.experiment_name + "/tunable_importance.html"
+                if plot_type == "optimization_history":
+                    plot = optuna.visualization.plot_optimization_history(study)
+                    plotFile = plotsDir + "/" + self.experiment_name + "/optimization_history.html"
+                if plot_type == "slice":
+                    plot = optuna.visualization.plot_slice(study)
+                    plotFile = plotsDir + "/" + self.experiment_name + "/slice.html"
+                if plot_type == "parallel_coordinate":
+                    plot = optuna.visualization.plot_parallel_coordinate(study)
+                    plotFile = plotsDir + "/" + self.experiment_name + "/parallel_coordinate.html"
+                # Commenting out contour plots as it gets hung sometimes when there are lot of tunables for a 100 trial experiment
+                #if plot_type == "contour":
+                #plot = optuna.visualization.plot_contour(study)
+                #plotFile = plotsDir + "/" + self.experiment_name + "/contour.html"
+
+                func = open(plotFile, "w")
+                func.write(plot.to_html())
+                func.close()
+                logger.info("ACCESS " + plot_type + " CHART AT <REST_SERVICE_URL>/plot?" + "experiment_name=" + self.experiment_name + "&type=" + plot_type)
+            except:
+                logger.warn("Issues creating" + plot_type + " html file")
+
 
 
 class Objective(TrialDetails):

--- a/src/rest_service.py
+++ b/src/rest_service.py
@@ -124,7 +124,7 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
 				return
 			# TODO : Validate plot type
 			if "type" not in query:
-				logger.info("Plot type not defined. Defaulting it to optimization_history")
+				logger.info("Plot type not defined. Defaulting it to tunable_importance")
 				plot_type = "tunable_importance"
 			else:
 				plot_type = query["type"][0]


### PR DESCRIPTION
Signed-off-by: kusumachalasani <kchalasa@redhat.com>

Description:
Generate the importance of all tunables and plots after the experiment 

1. Importance:
Generates the importance of tunables as json object after the experiment is complete in the log. 

2. Plots:
Generates plots for tunables_importance, slice, optimization_history, and parallel_coordinate for all the tunables after the experiment completes. The plots are saved as cache in hpo in a directory called plots. For each experiment, it creates a folder inside the plots directory and the plots are saved. The plots can be accessed through the URL mentioned in the log output.
Note: contour plots are not generated as the plot hangs if there are more no.of tunables (like 31 tunables + 100 trial data). If using specific tunables to plot it works better - which is not part of this PR.


Output log for tunables importance: 

2022-08-11 14:23:12 - INFO - bayes_optuna.optuna_hpo - TUNABLES IMPORTANCE:: {"AlwaysCompileLoopMethods": 0.09762756150924591, "NewRatio": 0.09609736984665643, "LoopUnrollLimit": 0.06821235138922051, "quarkus.datasource.jdbc.max-size": 0.06175839188432575, "MaxInlineLevel": 0.06056210175969281, "InlineSmallCode": 0.05529313793541708, "UseLoopPredicate": 0.04728835010604096, "gc": 0.04130452837904353, "UseTypeSpeculation": 0.033559474268803305, "UseSuperWord": 0.033559474268803305, "TieredCompilation": 0.033559474268803305, "ConcGCThreads": 0.033559474268803305, "CompileThreshold": 0.033559474268803305, "UseStringDeduplication": 0.03123606387490296, "quarkus.thread-pool.core-threads": 0.029428657114650543, "LoopUnrollMin": 0.02704307149816188, "BackgroundCompilation": 0.02316494684041285, "DoEscapeAnalysis": 0.02215576942018082, "UseInlineCaches": 0.020227845996300484, "quarkus.thread-pool.queue-size": 0.020021679071818167, "cpuRequest": 0.01969618295808506, "MinInliningThreshold": 0.01794144233135183, "AllowVectorizeOnDemand": 0.016779737134401652, "quarkus.datasource.jdbc.min-size": 0.01677973713440165, "MinSurvivorRatio": 0.015500279660071833, "TieredStopAtLevel": 0.0143658516862977, "StackTraceInThrowable": 0.014156677732970836, "nettyBufferCheck": 0.013548212063203832, "CompileThresholdScaling": 0.0020126813291282603, "FreqInlineSize": 9.329552540950751e-31, "memoryRequest": 5.685448766253697e-31, "quarkus.http.io-threads": 0.0, "AlwaysTenure": 0.0, "AlwaysPreTouch": 0.0, "AllowParallelDefineClass": 0.0}

Output log for plots information:
2022-08-17 12:34:51 - INFO - bayes_optuna.optuna_hpo - _ACCESS tunable_importance CHART AT <REST_SERVICE_URL>/plot?experiment_name=experiment_tfb-qrh991&type=tunable_importance_
2022-08-17 12:34:51 - INFO - bayes_optuna.optuna_hpo - _ACCESS optimization_history CHART AT <REST_SERVICE_URL>/plot?experiment_name=experiment_tfb-qrh991&type=optimization_history_
2022-08-17 12:34:52 - INFO - bayes_optuna.optuna_hpo - _ACCESS slice CHART AT <REST_SERVICE_URL>/plot?experiment_name=experiment_tfb-qrh991&type=slice_
2022-08-17 12:34:52 - INFO - bayes_optuna.optuna_hpo - _ACCESS parallel_coordinate CHART AT <REST_SERVICE_URL>/plot?experiment_name=experiment_tfb-qrh991&type=parallel_coordinate_