### PR TITLE
Change the ownership to hpo instead of root for all copied files in Dockerfile

### DIFF
--- a/Dockerfile.hpo
+++ b/Dockerfile.hpo
@@ -36,8 +36,7 @@ RUN microdnf install -y python39 gcc-c++ python39-devel python39-pip\
     && microdnf update -y \
     && microdnf -y install shadow-utils \
     # Setup the user for non-arbitrary UIDs with OpenShift
-    && useradd -d ${HPO_HOME} -u ${UID} -g 0 -m -s /bin/bash ${USER} \
-    && mkdir -p ${HPO_HOME}/app/src \
+    && useradd -d ${HPO_HOME} -u ${UID} -m -s /bin/bash ${USER} \
     && chmod -R g+rwx ${HPO_HOME} \
     && microdnf -y remove shadow-utils \
     && microdnf clean all
@@ -46,10 +45,10 @@ RUN microdnf install -y python39 gcc-c++ python39-devel python39-pip\
 USER ${UID}
 
 # copy the requirements file to the app directory to install required modules
-COPY requirements.txt index.html ${HPO_HOME}/app/
+COPY --chown=${USER} requirements.txt index.html experiment.html ${HPO_HOME}/app/
 
 # Copy ML hyperparameter tuning code
-COPY src ${HPO_HOME}/app/src/
+COPY --chown=${USER} src ${HPO_HOME}/app/src/
 
 WORKDIR ${HPO_HOME}/app
 # Install required python packages


### PR DESCRIPTION
Signed-off-by: kusumachalasani <kchalasa@redhat.com>

Description:
This fixes the issue #99

From the docker references, the default behavior of docker is to copy with root unless chown flag is used.

Attaching the snapshot from that document and reference:
```
All new files and directories are created with a UID and GID of 0, unless the optional --chown flag specifies a given username, groupname, or UID/GID combination to request specific ownership of the copied content.
```
Reference: https://docs.docker.com/engine/reference/builder/#copy

Ownership of files with new changes in Dockerfile:
```
[hpo@d5bf819453e0 app]$ ls -lrt
total 12
-rw-rw-r--. 1 hpo hpo   79 Sep 23 17:04 requirements.txt
-rw-rw-r--. 1 hpo hpo 1448 Sep 23 17:04 index.html
-rw-rw-r--. 1 hpo hpo  512 Sep 23 17:04 experiment.html
drwxr-xr-x. 5 hpo hpo   57 Sep 23 19:15 src
```