### PR TITLE
Fix parallel experiment issues

### DIFF
--- a/src/bayes_optuna/optuna_hpo.py
+++ b/src/bayes_optuna/optuna_hpo.py
@@ -31,13 +31,21 @@ class TrialDetails:
     A class containing the details of a trial such as trial number, tunable values suggested by Optuna, status of the
     experiment and the objective function value type and value.
     """
+    trial_number: int
+    trial_json_object: dict
+    trial_result_received: int
+    trial_result: str
+    result_value_type: str
+    result_value: float
 
-    trial_number = -1
-    trial_json_object = {}
-    trial_result_received = -1
-    trial_result = ""
-    result_value_type = ""
-    result_value = 0
+    def __init__(self, trial_number=-1,trial_json_object = {},trial_result_received = -1,trial_result = "",
+                 result_value_type = "",result_value = 0):
+        self.trial_number = trial_number
+        self.trial_json_object = trial_json_object
+        self.trial_result_received = trial_result_received
+        self.trial_result = trial_result
+        self.result_value_type = result_value_type
+        self.result_value = result_value
 
 
 class HpoExperiment:
@@ -54,16 +62,16 @@ class HpoExperiment:
     objective_function: str
     tunables: str
     value_type: str
-    trialDetails = TrialDetails()
-    resultsAvailableCond = threading.Condition()
-    experimentStartedCond = threading.Condition()
+    trialDetails: TrialDetails
+    resultsAvailableCond: threading.Condition
+    experimentStartedCond: threading.Condition
     isRunning = True
     started = False
     # recommended_config (json): A JSON containing the recommended config.
     recommended_config = {}
 
     def __init__(self, experiment_name, total_trials, parallel_trials, direction, hpo_algo_impl, id_,
-                 objective_function, tunables, value_type):
+                 objective_function, tunables, value_type, trialDetails):
         self.experiment_name = experiment_name
         self.total_trials = total_trials
         self.parallel_trials = parallel_trials
@@ -73,7 +81,9 @@ class HpoExperiment:
         self.objective_function = objective_function
         self.tunables = tunables
         self.value_type = value_type
-        self.trialDetails = TrialDetails()
+        self.trialDetails = trialDetails
+        self.resultsAvailableCond = threading.Condition()
+        self.experimentStartedCond = threading.Condition()
         self.thread = threading.Thread(target=self.recommend)
 
     def start(self) -> threading.Condition:

--- a/src/hpo_service.py
+++ b/src/hpo_service.py
@@ -37,9 +37,10 @@ class HpoService:
                       objective_function, tunables, value_type):
         try:
             self.expStateCond.acquire()
+            trial_details = optuna_hpo.TrialDetails()
             self.experiments[experiment_name] = optuna_hpo.HpoExperiment(experiment_name, total_trials, parallel_trials,
                                                                      direction, hpo_algo_impl, id_, objective_function,
-                                                                     tunables, value_type)
+                                                                     tunables, value_type, trial_details)
         finally:
             self.expStateCond.release()
 

--- a/src/rest_service.py
+++ b/src/rest_service.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import re
 import cgi
@@ -170,6 +171,7 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
 			logger.error(HPOErrorConstants.EXPERIMENT_EXISTS)
 			self._set_response(400, HPOErrorConstants.EXPERIMENT_EXISTS)
 		else:
+			logger.info("No. of threads running currently = "+str(threading.active_count()))
 			search_space_json = json_object["search_space"]
 			search_space = self.setDefaults(search_space_json)
 			if not search_space:
@@ -234,12 +236,13 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
 		return error_msg
 
 	def validate_trialNumber(self, experiment_name, trial_number):
+		current_trial_number = hpo_service.instance.get_trial_number(experiment_name)
 		errorMsg = ""
-		if not trial_number == str(hpo_service.instance.get_trial_number(experiment_name)):
+		if not int(trial_number) == current_trial_number:
 			try:
 				if int(trial_number) < 0:
 					errorMsg = HPOErrorConstants.NEGATIVE_TRIAL
-				else:
+				elif int(trial_number) > current_trial_number:
 					errorMsg = HPOErrorConstants.TRIAL_EXCEEDED
 			except ValueError:
 				errorMsg = HPOErrorConstants.NON_INTEGER_VALUE


### PR DESCRIPTION
Signed-off-by: Saad Khan <saakhan@redhat.com>

This PR aims to fix the existing parallel experiments issues #103 and #104 .

- Added constructor for TrialDetails class to initialize it for every new experiment.

- Moved the threadCondition inside the constructor in the HPOExperiment class to create a separate lock for each experiment threads.