### PR TITLE
Fix gRPC import issue while running only rest

### DIFF
--- a/scripts/cluster-helpers.sh
+++ b/scripts/cluster-helpers.sh
@@ -95,7 +95,7 @@ function native_start() {
 	if [ "$1" = "REST" ]; then
 		python3 -u src/service.py "REST"
 	else
-		python3 -u src/service.py
+		python3 -u src/service.py "BOTH"
 	fi
 }
 

--- a/src/service.py
+++ b/src/service.py
@@ -30,7 +30,7 @@ signal.signal(signal.SIGINT, signal_handler)
 def main():
 
     logger.info('Starting HPO service')
-    if sys.argv[1] == "BOTH":
+    if ( len(sys.argv) == 1 ) or ( len(sys.argv) == 2 and sys.argv[1] == "BOTH" ):
         import grpc_service
         gRPCservice = threading.Thread(target=grpc_service.serve)
         gRPCservice.daemon = True

--- a/src/service.py
+++ b/src/service.py
@@ -30,7 +30,7 @@ signal.signal(signal.SIGINT, signal_handler)
 def main():
 
     logger.info('Starting HPO service')
-    if len(sys.argv) == 1:
+    if sys.argv[1] == "BOTH":
         import grpc_service
         gRPCservice = threading.Thread(target=grpc_service.serve)
         gRPCservice.daemon = True

--- a/src/service.py
+++ b/src/service.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 import sys
 
-import rest_service, grpc_service
+import rest_service
 import threading
 import signal
 from logger import get_logger
@@ -31,6 +31,7 @@ def main():
 
     logger.info('Starting HPO service')
     if len(sys.argv) == 1:
+        import grpc_service
         gRPCservice = threading.Thread(target=grpc_service.serve)
         gRPCservice.daemon = True
         gRPCservice.start()


### PR DESCRIPTION
Signed-off-by: Saad Khan <saakhan@redhat.com>

This PR intends to fix issue #108 .

- Modified the gRPC import line in the `service.py` file to be imported only when both services are running.
- Tested the app by removing the gRPC libraries from the system and running both the services individually.