### PR TITLE
Update error messages for failed test cases

### DIFF
--- a/src/rest_service.py
+++ b/src/rest_service.py
@@ -257,6 +257,8 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
 					errorMsg = HPOErrorConstants.NEGATIVE_TRIAL
 				elif int(trial_number) > current_trial_number:
 					errorMsg = HPOErrorConstants.TRIAL_EXCEEDED
+				else:
+					errorMsg = HPOErrorConstants.TRIAL_PRECEDES
 			except ValueError:
 				errorMsg = HPOErrorConstants.NON_INTEGER_VALUE
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -53,6 +53,7 @@ class HPOErrorConstants:
     INVALID_TOTAL_TRIALS = "Total trials should be greater than 0!"
     NEGATIVE_TRIAL = "Trial number cannot be negative!"
     TRIAL_EXCEEDED = "Requested trial exceeds the completed trial limit!"
+    TRIAL_PRECEDES = "Requested trial is already completed!"
     NON_INTEGER_VALUE = "Only Integer value is allowed!"
     NEGATIVE_VALUE = "result_value cannot be negative!"
     VALUE_TYPE_MISMATCH = "Value and value type do not match!"

--- a/tests/scripts/hpo/hpo_post_exp_result_tests.sh
+++ b/tests/scripts/hpo/hpo_post_exp_result_tests.sh
@@ -70,7 +70,7 @@ function post_duplicate_exp_result() {
 
 		actual_result="${http_code}"
 		expected_result_="400"
-		expected_behaviour="Requested trial exceeds the completed trial limit"
+		expected_behaviour="Requested trial is already completed"
 
 		# Extract the lines from the service log after log_length_before_test
 		extract_lines=`expr ${log_length_before_test} + 1`
@@ -109,7 +109,7 @@ function post_same_id_different_exp_result() {
 
 		actual_result="${http_code}"
 		expected_result_="400"
-		expected_behaviour="Requested trial exceeds the completed trial limit"
+		expected_behaviour="Requested trial is already completed"
 
 		# Extract the lines from the service log after log_length_before_test
 		extract_lines=`expr ${log_length_before_test} + 1`


### PR DESCRIPTION
Signed-off-by: Saad Khan <saakhan@redhat.com>

This PR aims to fix couple of failed test cases in post_experiment case, `same-id-different-exp-result`  and  `duplicate-exp-result` .

These two cases were failing when trying to post the same result twice or posting the different result for same trial_number.

- Update condition in trial_number check
- Added new error message