### PR TITLE
Switching Ubuntu to 20.04 version to fix minikube installation issue

### DIFF
--- a/.github/workflows/test_on_pr.yaml
+++ b/.github/workflows/test_on_pr.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   test_on_docker:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "deploy"
   test_on_docker:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
Switching Ubuntu to 20.04 version to fix minikube installation issue for now.  Upgrading to latest versions, needs more investigation and will be captured here - https://github.com/kruize/autotune/issues/535

Signed-off-by: Chandrakala Subramanyam <csubrama@redhat.com>