### PR TITLE
Update error message for GET request with missing parameters

### DIFF
--- a/src/rest_service.py
+++ b/src/rest_service.py
@@ -100,7 +100,12 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
 		if re.search(HPOSupportedTypes.API_ENDPOINT, self.path):
 			query = parse_qs(urlparse(self.path).query)
 			if "experiment_name" not in query or "trial_number" not in query:
-				error_msg = HPOErrorConstants.MISSING_PARAMETERS
+				missing_params = []
+				if "experiment_name" not in query:
+					missing_params.append("experiment_name")
+				if "trial_number" not in query:
+					missing_params.append("trial_number")
+				error_msg = HPOErrorConstants.MISSING_PARAMETERS[:-1] + ": " + ", ".join(str(param) for param in missing_params)
 				logger.error(error_msg)
 				self._set_response(400, error_msg)
 				return


### PR DESCRIPTION
This PR aims to update the error message to Get a trial JSON object `GET /experiment_trials?experiment_name=<name>&trial_number=<trial-number>` by specifying the missing required parameters.