### PR TITLE
Include a parameter --port to start the hpo with custom server port.

### DIFF
--- a/deploy_hpo.sh
+++ b/deploy_hpo.sh
@@ -53,6 +53,7 @@ function usage() {
 	echo " -o | --container_image: deploy specific hpo container image name [Default - kruize/hpo:<version>]"
 	echo " -n | --namespace : Namespace to which hpo is deployed [Default - monitoring namespace for cluster type minikube]"
 	echo " -d | --configmaps_dir : Config maps directory [Default - manifests/configmaps]"
+	echo " -p | --port: hpo rest server port for cluster_type=native [Default - 8085]"
 	echo " --both: install both REST and the gRPC service"
 	echo " --rest: install REST only"
 	echo " Environment Variables to be set: REGISTRY, REGISTRY_EMAIL, REGISTRY_USERNAME, REGISTRY_PASSWORD"

--- a/deploy_hpo.sh
+++ b/deploy_hpo.sh
@@ -136,7 +136,7 @@ else
 fi
 
 # Get Service Status
-SERVICE_STATUS_NATIVE=$(ps -u | grep service.py | grep -v grep)
+SERVICE_STATUS_NATIVE=$(ps -ef | grep src/service.py | grep -v grep)
 SERVICE_STATUS_DOCKER=$(${CONTAINER_RUNTIME} ps | grep hpo_docker_container)
 
 # Call the proper setup function based on the cluster_type

--- a/deploy_hpo.sh
+++ b/deploy_hpo.sh
@@ -36,6 +36,7 @@ hpo_ns=""
 # docker: loop timeout is turned off by default
 timeout=-1
 service_type="both"
+service_port="8085"
 
 # source the helpers script
 source ${SCRIPTS_DIR}/cluster-helpers.sh
@@ -70,7 +71,7 @@ function check_cluster_type() {
 	esac
 }
 
-VALID_ARGS=$(getopt -o ac:d:o:n:strb --long non_interactive,cluster_type:,configmaps:,container_image:,namespace:,start,terminate,rest,both -- "$@")
+VALID_ARGS=$(getopt -o ac:d:o:n:p:strb --long non_interactive,cluster_type:,configmaps:,container_image:,namespace:,start,terminate,rest,both,port: -- "$@")
 if [[ $? -ne 0 ]]; then
 	usage
 	exit 1;
@@ -102,6 +103,10 @@ while [ : ]; do
 		hpo_ns="$2"
 		shift 2
 		;;
+	-p | --port)
+                service_port="$2"
+                shift 2
+                ;;
 	-s | --start)
 		setup=1
 		shift
@@ -142,7 +147,7 @@ SERVICE_STATUS_DOCKER=$(${CONTAINER_RUNTIME} ps | grep hpo_docker_container)
 # Call the proper setup function based on the cluster_type
 if [ ${setup} == 1 ]; then
 	if [ ${cluster_type} = "native" ]; then
-		${cluster_type}_start ${service_type}
+		${cluster_type}_start ${service_type} ${service_port}
 	elif [ ${cluster_type} = "operate-first" ]; then
 		echo
 		echo "Info: Access HPO at ${Op_first_URL}"

--- a/scripts/cluster-helpers.sh
+++ b/scripts/cluster-helpers.sh
@@ -108,7 +108,7 @@ function native_terminate() {
 	# check if service is already stopped
 	check_prereq stopped ${SERVICE_STATUS_NATIVE}
 
-	ps -u | grep service.py | grep -v grep | awk '{print $2}' | xargs kill -9 >/dev/null 2>&1
+	ps -ef | grep src/service.py | grep -v grep | awk '{print $2}' | xargs kill -9 >/dev/null 2>&1
 	check_err "Failed to stop HPO Service!"
 
 	# restore experiment.html after HPO terminates in native

--- a/scripts/cluster-helpers.sh
+++ b/scripts/cluster-helpers.sh
@@ -93,9 +93,9 @@ function native_start() {
 	cp experiment.html experiment_torestore.html
 
 	if [ "$1" = "REST" ]; then
-		python3 -u src/service.py "REST"
+		python3 -u src/service.py "REST" "$2"
 	else
-		python3 -u src/service.py "BOTH"
+		python3 -u src/service.py "BOTH" "$2"
 	fi
 }
 

--- a/src/rest_service.py
+++ b/src/rest_service.py
@@ -322,11 +322,12 @@ def get_search_create_study(search_space_json, operation):
 			return response
 
 
-def main():
-	server = HTTPServer((HPOSupportedTypes.SERVER_HOSTNAME, HPOSupportedTypes.SERVER_PORT), HTTPRequestHandler)
-	logger.info("Access REST Service at http://%s:%s" % ("localhost", HPOSupportedTypes.SERVER_PORT))
-	server.serve_forever()
+def main(server_port=8085):
+    hpo_instance = HPOSupportedTypes(server_port=server_port)
+    server = HTTPServer((HPOSupportedTypes.SERVER_HOSTNAME,  hpo_instance.SERVER_PORT), HTTPRequestHandler)
+    logger.info("Access REST Service at http://%s:%s" % ("localhost",  hpo_instance.SERVER_PORT))
+    server.serve_forever()
 
 
 if __name__ == '__main__':
-	main()
+    main(server_port=8085)

--- a/src/service.py
+++ b/src/service.py
@@ -34,7 +34,7 @@ def main():
         gRPCservice = threading.Thread(target=grpc_service.serve)
         gRPCservice.daemon = True
         gRPCservice.start()
-    if (sys.argv[2] != ''):
+    if ( len(sys.argv) == 3 and sys.argv[2] != '' ):
         server_port = int(sys.argv[2])
     else:
         server_port=8085

--- a/src/service.py
+++ b/src/service.py
@@ -29,14 +29,16 @@ signal.signal(signal.SIGINT, signal_handler)
 
 def main():
 
-    logger.info('Starting HPO service')
-    if ( len(sys.argv) == 1 ) or ( len(sys.argv) == 2 and sys.argv[1] == "BOTH" ):
+    if ( len(sys.argv) == 1 ) or ( len(sys.argv) == 2 and sys.argv[1] == "BOTH" ) or ( len(sys.argv) == 3 and sys.argv[1] == "BOTH" ):
         import grpc_service
         gRPCservice = threading.Thread(target=grpc_service.serve)
         gRPCservice.daemon = True
         gRPCservice.start()
-
-    restService = threading.Thread(target=rest_service.main)
+    if (sys.argv[2] != ''):
+        server_port = int(sys.argv[2])
+    else:
+        server_port=8085
+    restService = threading.Thread(target=rest_service.main, args=(server_port,))
     restService.daemon = True
     restService.start()
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -28,7 +28,6 @@ class HPOSupportedTypes:
     N_JOBS = 1
     N_TRIALS = 10
     SERVER_HOSTNAME = "0.0.0.0"
-    #SERVER_PORT = 8085
     API_ENDPOINT = "/experiment_trials"
     CONTENT_TYPE = "application/json"
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -28,9 +28,13 @@ class HPOSupportedTypes:
     N_JOBS = 1
     N_TRIALS = 10
     SERVER_HOSTNAME = "0.0.0.0"
-    SERVER_PORT = 8092
+    #SERVER_PORT = 8085
     API_ENDPOINT = "/experiment_trials"
     CONTENT_TYPE = "application/json"
+
+    def __init__(self, server_port=None):
+        if server_port is not None:
+            self.SERVER_PORT = server_port
 
 
 class HPOErrorConstants:

--- a/src/utils.py
+++ b/src/utils.py
@@ -28,7 +28,7 @@ class HPOSupportedTypes:
     N_JOBS = 1
     N_TRIALS = 10
     SERVER_HOSTNAME = "0.0.0.0"
-    SERVER_PORT = 8085
+    SERVER_PORT = 8092
     API_ENDPOINT = "/experiment_trials"
     CONTENT_TYPE = "application/json"
 


### PR DESCRIPTION
Include a parameter --port to start the hpo with custom server port.
Currently, hpo starts with 8085 hardcoded port in native.  In cases where we cannot use 8085, passing the --port helps.